### PR TITLE
feat: subscription client provide connection alive callback

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -107,16 +107,17 @@ type SubscriptionProtocol interface {
 // SubscriptionContext represents a shared context for protocol implementations with the websocket connection inside
 type SubscriptionContext struct {
 	context.Context
-	websocketConn    WebsocketConn
-	OnConnected      func()
-	onDisconnected   func()
-	cancel           context.CancelFunc
-	subscriptions    map[string]Subscription
-	disabledLogTypes []OperationMessageType
-	log              func(args ...interface{})
-	acknowledged     int32
-	exitStatusCodes  []int
-	mutex            sync.Mutex
+	websocketConn     WebsocketConn
+	OnConnected       func()
+	onDisconnected    func()
+	onConnectionAlive func()
+	cancel            context.CancelFunc
+	subscriptions     map[string]Subscription
+	disabledLogTypes  []OperationMessageType
+	log               func(args ...interface{})
+	acknowledged      int32
+	exitStatusCodes   []int
+	mutex             sync.Mutex
 }
 
 // Log prints condition logging with message type filters
@@ -416,6 +417,12 @@ func (sc *SubscriptionClient) OnConnected(fn func()) *SubscriptionClient {
 // OnDisconnected event is triggered when the websocket client was disconnected
 func (sc *SubscriptionClient) OnDisconnected(fn func()) *SubscriptionClient {
 	sc.context.onDisconnected = fn
+	return sc
+}
+
+// OnConnectionAlive event is triggered when the websocket receive a connection alive message (differs per protocol)
+func (sc *SubscriptionClient) OnConnectionAlive(fn func()) *SubscriptionClient {
+	sc.context.onConnectionAlive = fn
 	return sc
 }
 

--- a/subscription_graphql_ws.go
+++ b/subscription_graphql_ws.go
@@ -132,6 +132,9 @@ func (gws *graphqlWS) OnMessage(ctx *SubscriptionContext, subscription Subscript
 		_ = gws.Unsubscribe(ctx, message.ID)
 	case GQLPing:
 		ctx.Log(message, "server", GQLPing)
+		if ctx.onConnectionAlive != nil {
+			ctx.onConnectionAlive()
+		}
 		// send pong response message back to the server
 		msg := OperationMessage{
 			Type:    GQLPong,

--- a/subscriptions_transport_ws.go
+++ b/subscriptions_transport_ws.go
@@ -164,6 +164,9 @@ func (stw *subscriptionsTransportWS) OnMessage(ctx *SubscriptionContext, subscri
 		_ = stw.Unsubscribe(ctx, message.ID)
 	case GQLConnectionKeepAlive:
 		ctx.Log(message, "server", GQLConnectionKeepAlive)
+		if ctx.onConnectionAlive != nil {
+			ctx.onConnectionAlive()
+		}
 	case GQLConnectionAck:
 		// Expected response to the ConnectionInit message from the client acknowledging a successful connection with the server.
 		// The client is now ready to request subscription operations.


### PR DESCRIPTION
This PR enables optionally provided an `onConnectionAlive` function that will be called when connection alive message is received by the subscription.

This is useful for implementing healthchecks on top of the connection status, as instructed by connection alive messages (actual message differs per protocol).